### PR TITLE
Add GrowingIO ignore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ module.exports = {
   _initContainer(el, useShadowDom) {
     if (!el) {
       el = document.createElement('div')
+      el.setAttribute('growing-ignore', true)
       document.documentElement.appendChild(el)
     }
 


### PR DESCRIPTION
添加了GrowingIO的忽略属性，否则点击事件上报 会导致网络选项卡无法点击查看详情