### PR TITLE
Network request now looks like a table

### DIFF
--- a/src/Network/Network.scss
+++ b/src/Network/Network.scss
@@ -17,6 +17,7 @@
         margin-bottom: 10px;
         li {
           @include overflow-auto(x);
+          display: flex;
           cursor: pointer;
           border-top: 1px solid $gray-light;
           height: 41px;
@@ -27,7 +28,8 @@
             }
           }
           span {
-            display: inline-block;
+            flex: 0 0 calc(100% / 7);
+            overflow: auto;
             line-height: 40px;
             height: 40px;
             padding: 0 10px;


### PR DESCRIPTION
I suppose that network tool should looks like a table. So, I made a few changes for styles.

**Demo landscape**
![demo_landscape](https://user-images.githubusercontent.com/8425363/66115432-e2623500-e5e1-11e9-8a36-8711673010c7.png)

**Demo portrait**
![demo_portait](https://user-images.githubusercontent.com/8425363/66115433-e2623500-e5e1-11e9-9d8b-743042df67da.png)

