### PR TITLE
fix: logger component blinks frequently as it scroll to the border.

### DIFF
--- a/src/Console/Logger.js
+++ b/src/Console/Logger.js
@@ -636,7 +636,7 @@ export default class Logger extends Emitter {
     this._$container.on('scroll', () => {
       const { scrollHeight, offsetHeight, scrollTop } = this._container
       // safari bounce effect
-      if (scrollTop < 0) return
+      if (scrollTop <= 0) return
       if (offsetHeight + scrollTop > scrollHeight) return
 
       let isAtBottom = false


### PR DESCRIPTION
I use it in IOS system, when the console list exceeds the screen height, there will be flicker when scrolling to the top or bottom.

This pull request is for fix scroll blinks issue.