### PR TITLE
增加本地存储的编辑功能

### DIFF
--- a/src/Resources/Resources.hbs
+++ b/src/Resources/Resources.hbs
@@ -19,7 +19,9 @@
           {{#each localStoreData}}
             <tr>
               <td {{{class 'key'}}}>{{key}}</td>
-              <td {{{class 'storage-val'}}} data-key="{{key}}" data-type="local">{{val}}</td>
+              <td {{{class 'storage-val'}}} data-key="{{key}}" data-type="local">{{val}}
+                  <div {{{class 'edit-val'}}}></div>
+              </td>
               <td {{{class 'control'}}}>
                 <span {{{class 'icon-delete delete-storage'}}} data-key="{{key}}" data-type="local"></span>
               </td>
@@ -55,7 +57,9 @@
         {{#each sessionStoreData}}
           <tr>
             <td {{{class 'key'}}}>{{key}}</td>
-            <td {{{class 'storage-val'}}} data-key="{{key}}" data-type="session">{{val}}</td>
+            <td {{{class 'storage-val'}}} data-key="{{key}}" data-type="session">{{val}}
+                  <div {{{class 'edit-val'}}}></div>
+            </td>
             <td {{{class 'control'}}}>
               <span {{{class 'icon-delete delete-storage'}}} data-key="{{key}}" data-type="session"></span>
             </td>
@@ -91,7 +95,11 @@
           {{#each cookieData}}
             <tr>
               <td {{{class 'key'}}}>{{key}}</td>
-              <td>{{val}}</td>
+              {{!-- <td>{{val}}</td> --}}
+              <td {{{class 'cookie-val'}}} data-key="{{key}}" data-type="cookie">
+                  {{val}}
+                  <div {{{class 'edit-val'}}}></div>
+              </td>
               <td {{{class 'control'}}}>
                 <span {{{class 'icon-delete delete-cookie'}}} data-key="{{key}}"></span>
               </td>
@@ -182,3 +190,4 @@
     {{/if}}
   </ul>
 </div>
+

--- a/src/Resources/Resources.js
+++ b/src/Resources/Resources.js
@@ -312,6 +312,38 @@ export default class Resources extends Tool {
           showSources('raw', val)
         }
       })
+      .on('click', '.eruda-edit-val', function(e) {
+        e.stopPropagation();
+
+        const $this = $(this)
+        const key = $this.parent().data('key')
+        const type = $this.parent().data('type')
+
+        let val
+        switch (type) {
+            case 'local':
+                val = localStorage.getItem(key)
+                break;
+            case 'session':
+                val = sessionStorage.getItem(key)
+                break;
+            case 'cookie':
+                self._cookieData.some(item => {
+                    if (item.key == key) {
+                        val = item.val
+                        return true
+                    }
+                })
+                break;
+        
+            default:
+                break;
+        }
+
+        const sources = container.get('sources')
+        sources && sources.enableEditMode(type, key);
+        showSources('raw', val)
+      })
       .on('click', '.eruda-img-link', function() {
         const src = $(this).attr('src')
 
@@ -341,7 +373,7 @@ export default class Resources extends Tool {
 
         const url = $(this).attr('href')
 
-        if (type === 'iframe' || !sameOrigin(location.href, url)) {
+	if (type === 'iframe' || !sameOrigin(location.href, url)) {
           showSources('iframe', url)
         } else {
           ajax({
@@ -543,3 +575,4 @@ const sliceStr = (str, len) =>
 const regImg = /\.(jpeg|jpg|gif|png)$/
 
 const isImg = url => regImg.test(url)
+

--- a/src/Resources/Resources.scss
+++ b/src/Resources/Resources.scss
@@ -102,6 +102,19 @@
           }
         }
       }
+
+      &[data-type]{
+          position: relative;
+
+          .edit-val{
+            @include absolute();
+            left: 50%;
+            width: 50%;
+            background-color: #eee;
+            opacity: .25;
+          }
+      }
     }
   }
 }
+

--- a/src/Sources/Sources.js
+++ b/src/Sources/Sources.js
@@ -15,6 +15,9 @@ export default class Sources extends Tool {
     this._showLineNum = true
     this._formatCode = true
     this._indentSize = 4
+    this._editMode = false
+    this._storageType = ''
+    this._storageKey = ''
 
     this._loadTpl()
   }
@@ -30,6 +33,16 @@ export default class Sources extends Tool {
 
     evalCss.remove(this._style)
     this._rmCfg()
+  }
+  enableEditMode(type, key){
+    this._editMode = true
+    this._storageType = type
+    this._storageKey = key
+  }
+  disableEditMode(){
+    this._editMode = false;
+    this._storageType = ''
+    this._storageKey = ''
   }
   set(type, val) {
     if (type === 'img') {
@@ -257,7 +270,11 @@ export default class Sources extends Tool {
     objViewer.set(val)
   }
   _renderRaw() {
-    this._renderHtml(this._rawTpl({ val: this._data.val }))
+    this._renderHtml(this._rawTpl({ val: this._data.val, editMode: this._editMode }), false)
+    if (this._editMode) {
+        this._editStorage()
+        this.disableEditMode()
+    }
   }
   _renderIframe() {
     this._renderHtml(this._iframeTpl({ src: this._data.val }))
@@ -269,7 +286,37 @@ export default class Sources extends Tool {
     // Need setTimeout to make it work
     setTimeout(() => (this._$el.get(0).scrollTop = 0), 0)
   }
+  _editStorage(){
+    const type = this._storageType
+    const key = this._storageKey
+
+    this._$el.find('.eruda-raw-wrapper textarea')
+        .on('input', function (){
+            const val = this.value.trim();
+            switch (type) {
+                case 'cookie':
+                    setCookie(key, val)
+                    break;
+                case 'local':
+                    localStorage[key] = val
+                    break;
+                case 'session':
+                    sessionStorage[key] = val
+                    break;
+                default:
+                    break;
+            }
+        })
+  }
+}
+
+function setCookie(cname, cvalue, exdays = 1) {
+  var d = new Date();
+  d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+  var expires = 'expires=' + d.toUTCString();
+  document.cookie = cname + '=' + cvalue + ';' + expires + ';path=/';
 }
 
 const MAX_BEAUTIFY_LEN = 100000
 const MAX_LINE_NUM_LEN = 400000
+

--- a/src/Sources/Sources.scss
+++ b/src/Sources/Sources.scss
@@ -9,6 +9,19 @@
     @include overflow-auto(x);
     width: 100%;
     min-height: 100%;
+
+    textarea {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        padding: 0;
+        margin: 0;
+        border: none;
+        resize: none;
+	user-select: all;
+    }
   }
   .raw {
     user-select: text;
@@ -66,3 +79,4 @@
     height: 100%;
   }
 }
+

--- a/src/Sources/raw.hbs
+++ b/src/Sources/raw.hbs
@@ -1,3 +1,8 @@
 <div {{{class 'raw-wrapper'}}}>
-  <div {{{class 'raw'}}}>{{val}}</div>
+  {{#if editMode}}
+    <textarea>{{val}}</textarea>
+  {{else}}
+    <div {{{class 'raw'}}}>{{val}}</div>
+  {{/if}}
 </div>
+


### PR DESCRIPTION
项目里经常要操作本地存储（localStorage，sessionStorage，cookie）来方便功能测试，所以增加了对应的编辑功能。

打开resourse面板，在每个值旁边会有个淡淡的灰色块，点击相应色块即可进入编辑模式。用了绝对定位，所以不会占据原空间。

![1602771841404](https://user-images.githubusercontent.com/995572/96143279-868cf480-0f35-11eb-8b95-2e3ac7fd169d.jpg)
