### PR TITLE
fix: resources stylesheel show failed

### DIFF
--- a/src/Resources/Resources.js
+++ b/src/Resources/Resources.js
@@ -121,7 +121,7 @@ export default class Resources extends Tool {
 
     const stylesheetState = getState('stylesheet', stylesheetData.length)
     let stylesheetDataHtml = '<li>Empty</li>'
-    if (!stylesheetData) {
+    if (!isEmpty(stylesheetData)) {
       stylesheetDataHtml = map(stylesheetData, (stylesheet) => {
         stylesheet = escape(stylesheet)
         return ` <li><a href="${stylesheet}" target="_blank" class="${c(


### PR DESCRIPTION
## Problem Description

Resources Stylesheet always show empty.

![image](https://user-images.githubusercontent.com/23225539/226150428-2e7b9b9f-eac1-47fc-97d9-be3b6c71e21e.png)

## Solution

Repair judgment condition.

