### PR TITLE
fix: mouse cannot be used on devices with touchscreen

### DIFF
--- a/src/DevTools/DevTools.js
+++ b/src/DevTools/DevTools.js
@@ -23,7 +23,7 @@ import LunaModal from 'luna-modal'
 import LunaTab from 'luna-tab'
 import {
   classPrefix as c,
-  drag,
+  dragEvents,
   eventClient,
   hasSafeArea,
   safeStorage,
@@ -327,8 +327,8 @@ export default class DevTools extends Emitter {
 
       $resizer.css('height', '100%')
 
-      $document.on(drag('move'), moveListener)
-      $document.on(drag('end'), endListener)
+      dragEvents('move').forEach(e => $document.on(e, moveListener))
+      dragEvents('end').forEach(e => $document.on(e, endListener))
     }
     const moveListener = (e) => {
       if (!this._isResizing) {
@@ -354,11 +354,11 @@ export default class DevTools extends Emitter {
 
       $resizer.css('height', 10)
 
-      $document.off(drag('move'), moveListener)
-      $document.off(drag('end'), endListener)
+      dragEvents('move').forEach(e => $document.off(e, moveListener))
+      dragEvents('end').forEach(e => $document.off(e, endListener))
     }
     $resizer.css('height', 10)
-    $resizer.on(drag('start'), startListener)
+    dragEvents('start').forEach(e => $resizer.on(e, startListener))
 
     $navBar.on('contextmenu', (e) => e.preventDefault())
     this.$container.on('click', (e) => e.stopPropagation())

--- a/src/EntryBtn/EntryBtn.js
+++ b/src/EntryBtn/EntryBtn.js
@@ -4,7 +4,7 @@ import Emitter from 'licia/Emitter'
 import $ from 'licia/$'
 import nextTick from 'licia/nextTick'
 import orientation from 'licia/orientation'
-import { pxToNum, classPrefix as c, drag, eventClient } from '../lib/util'
+import { pxToNum, classPrefix as c, dragEvents, eventClient } from '../lib/util'
 import evalCss from '../lib/evalCss'
 
 const $document = $(document)
@@ -84,6 +84,8 @@ export default class EntryBtn extends Emitter {
     this.setPos(pos)
   }
   _onDragStart = (e) => {
+    e.preventDefault()
+
     const $el = this._$el
     $el.addClass(c('active'))
 
@@ -93,8 +95,8 @@ export default class EntryBtn extends Emitter {
     this._oldX = pxToNum($el.css('left'))
     this._oldY = pxToNum($el.css('top'))
     this._startY = eventClient('y', e)
-    $document.on(drag('move'), this._onDragMove)
-    $document.on(drag('end'), this._onDragEnd)
+    dragEvents('move').forEach(e => $document.on(e, this._onDragMove))
+    dragEvents('end').forEach(e => $document.on(e, this._onDragEnd))
   }
   _onDragMove = (e) => {
     const btnSize = this._$el.get(0).offsetWidth
@@ -132,8 +134,8 @@ export default class EntryBtn extends Emitter {
     }
 
     this._onDragMove(e)
-    $document.off(drag('move'), this._onDragMove)
-    $document.off(drag('end'), this._onDragEnd)
+    dragEvents('move').forEach(e => $document.off(e, this._onDragMove))
+    dragEvents('end').forEach(e => $document.off(e, this._onDragEnd))
 
     const cfg = this.config
 
@@ -149,7 +151,7 @@ export default class EntryBtn extends Emitter {
   _bindEvent() {
     const $el = this._$el
 
-    $el.on(drag('start'), this._onDragStart)
+    dragEvents('start').forEach(e => $el.on(e, this._onDragStart))
 
     orientation.on('change', () => this._resetPos(true))
     window.addEventListener('resize', () => this._resetPos())

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -5,7 +5,6 @@ import isUndef from 'licia/isUndef'
 import last from 'licia/last'
 import map from 'licia/map'
 import memStorage from 'licia/memStorage'
-import root from 'licia/root'
 import toNum from 'licia/toNum'
 import trim from 'licia/trim'
 import html from 'licia/html'
@@ -150,7 +149,6 @@ function processClass(str) {
   }).join(' ')
 }
 
-const hasTouchSupport = 'ontouchstart' in root
 const touchEvents = {
   start: 'touchstart',
   move: 'touchmove',
@@ -162,8 +160,8 @@ const mouseEvents = {
   end: 'mouseup',
 }
 
-export function drag(name) {
-  return hasTouchSupport ? touchEvents[name] : mouseEvents[name]
+export function dragEvents(name) {
+  return [touchEvents[name], mouseEvents[name]]
 }
 
 export function eventClient(type, e) {


### PR DESCRIPTION
When using a mouse on a phone, cannot open or resize the eruda window. (very edge case I know...)

To fix it, I just added code to always handle both touch and mouse events, and make sure to call `preventDefault` on the touch event so the `mousedown` doesn't get fired again.

Attached video has 2 parts:
 - reproduce the issue in the homepage
 - fix result using the test page, both open, close, move entry, and resize all work.

https://github.com/liriliri/eruda/assets/3515649/de453903-a85d-4367-b0e5-d871b67a9c9e

