### PR TITLE
Tweak bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Browse it on your phone: [https://eruda.liriliri.io/](https://eruda.liriliri.io/
 In order to try it for different sites, execute the script below on browser address bar.
 
 ```javascript
-javascript:(function () { var script = document.createElement('script'); script.src="//cdn.jsdelivr.net/npm/eruda"; document.body.appendChild(script); script.onload = function () { eruda.init() } })();
+javascript:(function () { var script = document.createElement('script'); script.src="https://cdn.jsdelivr.net/npm/eruda"; document.body.append(script); script.onload = function () { eruda.init(); } })();
 ```
 
 ## Features

--- a/README_CN.md
+++ b/README_CN.md
@@ -38,7 +38,7 @@
 如果想在其它页面尝试，请在浏览器地址栏上输入以下代码。
 
 ```javascript
-javascript:(function () { var script = document.createElement('script'); script.src="//cdn.jsdelivr.net/npm/eruda"; document.body.appendChild(script); script.onload = function () { eruda.init() } })();
+javascript:(function () { var script = document.createElement('script'); script.src="https://cdn.jsdelivr.net/npm/eruda"; document.body.append(script); script.onload = function () { eruda.init(); } })();
 ```
 
 ## 功能清单


### PR DESCRIPTION
It’s strictly better to always explicitly use https:// (instead of protocol-relative URLs) for resources that are available over that protocol.