### PR TITLE
chore: update third party plugins in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If you want to create a plugin yourself, follow the guides [here](https://eruda.
 
 * [eruda-pixel](https://github.com/Faithree/eruda-pixel): UI pixel restoration tool.
 * [eruda-webpack-plugin](https://github.com/huruji/eruda-webpack-plugin): Eruda webpack plugin.
+* [eruda-vue-devtools](https://github.com/Zippowxk/vue-devtools-plugin): Eruda Vue-devtools plugin.
 
 ## Backers
 


### PR DESCRIPTION
Add Eruda-vue-devtools plugin to ReadMe

![eruda-desktop](https://github.com/liriliri/eruda/assets/5326755/aee62f4b-a13b-4014-b578-a612c74930be)
