### PR TITLE
Emit `error` from Console when unhandled error is logged

### DIFF
--- a/src/Console/Console.js
+++ b/src/Console/Console.js
@@ -121,6 +121,7 @@ export default class Console extends Tool {
   }
   _handleErr = (err) => {
     this._logger.error(err)
+    this.emit('error', err)
   }
   _enableJsExecution(enabled) {
     const $el = this._$el


### PR DESCRIPTION
Let me know if this doesn't make sense, but I feel like it'd be good to emit this after logging the error. It could also be another event, but I didn't want to introduce new events.