### PR TITLE
Hide eruda when printing

### DIFF
--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -61,6 +61,12 @@
   }
 }
 
+@media print {
+  #eruda {
+    display: none !important;
+  }
+}
+
 .tag-name-color {
   color: var(--tag-name-color);
 }
@@ -80,3 +86,4 @@
 .string-color {
   color: var(--string-color);
 }
+


### PR DESCRIPTION
The button and the console should not be visible when printing.